### PR TITLE
Create PyPi releases on tag push.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,21 @@ workflows:
   test:
     jobs:
       - test:
+          filters:
+            tags:
+              only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
               python_version: ["2.7", "3.5"]
               debian_version: ["stretch"]
+      - pypi:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /v?[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
 
 jobs:
   test:
@@ -57,3 +68,35 @@ jobs:
             pycodestyle ./eox_tagging
             pylint ./eox_tagging --rcfile=./setup.cfg
             isort --check-only --recursive --diff ./eox_tagging
+
+  pypi:
+    docker:
+      - image: circleci/python:3.5
+    steps:
+      - checkout
+      - run:
+          name: Init .pypirc
+          command: |
+            echo $'[distutils]\nindex-servers = pypi\n[pypi]' > ~/.pypirc
+            echo -e "username = $PYPI_USERNAME" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: Prepare venv for distribution
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install twine
+      - run:
+          name: Create package
+          command: |
+            python setup.py sdist bdist_wheel
+      - run:
+          name: Check package
+          command: |
+            source venv/bin/activate
+            twine check dist/*
+      - run:
+          name: Upload to pypi
+          command: |
+            source venv/bin/activate
+            twine upload dist/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change Log
 Unreleased
 ----------
 
-*
+* First PyPI release.
 
 [0.1.0] - 2020-06-23
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ import re
 
 from setuptools import setup
 
+with open("README.rst", "r") as fh:
+    README = fh.read()
+
 
 def load_requirements(*requirements_paths):
     """
@@ -63,8 +66,22 @@ setup(
     name='eox_tagging',
     version=VERSION,
     description='eox-tagging',
+    long_description=README,
+    long_description_content_type='text/x-rst',
+    license="AGPL",
     author='eduNEXT',
     author_email='contact@edunext.co',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Framework :: Django :: 1.11',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+    ],
     packages=[
         'eox_tagging',
     ],


### PR DESCRIPTION
Create PyPi releases on tag push.

This will create a PyPi release every time that we create a release that matches with this regex  ` /v?[0-9]+(\.[0-9]+)*/` i.e. (v0.1.0, v0.2.0, v1.0.0 ...).

This will done if the tests for that release  are passing.

We have applied these changes successfully in eox-core and flow-control-xblock.