### PR TITLE
Refactor get_queryset in Tag viewset

### DIFF
--- a/eox_tagging/api/v1/test/test_viewset.py
+++ b/eox_tagging/api/v1/test/test_viewset.py
@@ -66,8 +66,15 @@ class TestTagViewSet(TestCase):
             expiration_date=datetime.date(2020, 10, 19),
         )
 
+        self.example_tag_2 = Tag.objects.create(
+            tag_value="example_tag_value",
+            tag_type="example_tag_2",
+            target_object=self.target_object,
+            owner_object=self.owner_site,
+            access=AccessLevel.PRIVATE,
+            expiration_date=datetime.date(2020, 10, 19),
+        )
         self.KEY = self.example_tag.key.hex
-
         # Test URLs
         self.URL = reverse("tag-list")
         self.URL_DETAILS = reverse("tag-detail", args=[self.KEY])


### PR DESCRIPTION
This PR separates getting the owner of the tags to be returned when listing/retrieving. I think it is more clear this way to determine how to filter the queryset so tags are only available to the corresponding owner.