### PR TITLE
Refactor filters

### DIFF
--- a/eox_tagging/api/v1/test/test_viewset.py
+++ b/eox_tagging/api/v1/test/test_viewset.py
@@ -255,7 +255,8 @@ class TestTagViewSet(TestCase):
 
         response = self.client.get(self.URL, query_params)
 
-        self.assertEqual(response.status_code, 200)
+        data = response.json().get("results")[0].get("meta")
+        self.assertEqual(data.get("target_id"), "user_test")
 
     @patch_permissions
     def test_filter_by_owner_user(self, _):

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -87,7 +87,6 @@ class TagQuerySet(QuerySet):
             object_id = {
                 "opaque_key": CourseKey.from_string(object_id),
             }
-
         object_instance = ctype.get_object_for_this_type(**object_id)
 
         return object_instance, ctype


### PR DESCRIPTION
This PR deletes redundancy in the filters method, replacing find_by_<name>,  where name was a field_name of a target model, with find_by_target_object