### PR TITLE
Datetime validations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 ----------
 
 * Changed Date fields like expiration date and activation date to DateTime fields
+* Added validations only for DateTime fields
 
 [0.2.0] - 2020-06-26
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,10 @@ Important notes:
 +---------------+-------------------------------------------------------+----------------------------------------------------------------+
 |``opaque_key`` | the field must be an opaque key                       |  ``validate_tag_value : {"opaque_key": "CourseKey"}``          |
 +---------------+-------------------------------------------------------+----------------------------------------------------------------+
+| ``between``   | the field must be greater than the first member of    |  ``validate_expiration_date : {"between": [DATE_1, DATE_2]}``  |
+|               | the list and less than the last member. Or can be     |                                                                |
+|               | equal to one of the two. The list must be sorted.     |                                                                |
++---------------+-------------------------------------------------------+----------------------------------------------------------------+
 
 
 * The available objects to tag and validate are: User, Site, CourseOverview and CourseEnrollment
@@ -152,7 +156,8 @@ This means that:
 * The field access can be `private` or `public`.
 * The target type must be equal to `CourseEnrollment`
 * Tag type must be equal to tag_by_edunext.
-* The tag activation date must exist and be in the values defined in the array
+* The tag activation date must exist and be between the values defined in the array. This means: value_1 <= activation_date <= value_2.
+  The array must be sorted or a validation error will be raised.
 
 Tagging REST API
 ================

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -1,7 +1,6 @@
 """
 Model to store tags in the database.
 """
-import datetime
 import logging
 import re
 import uuid
@@ -206,23 +205,10 @@ class Tag(models.Model):
         if attr and re.match(r".+object$|.+object_type$", attr):
             return self.__get_model(attr, name)
 
-        if attr in ['activation_date', 'expiration_date']:
-            return self.__get_dates(attr)
-
         if attr == 'access':
             return self.__get_field_choice(attr)
 
         return getattr(self, attr)
-
-    def __get_dates(self, attr):
-        """Function that gets formatted dates for the model."""
-        date = getattr(self, attr)
-        date_format = "%b %d %Y %H:%M:%S"
-        try:
-            date_str = datetime.datetime.strftime(date, date_format)
-        except TypeError:
-            return None
-        return date_str
 
     def __get_model(self, attr, name):
         """

--- a/eox_tagging/test/test_models.py
+++ b/eox_tagging/test/test_models.py
@@ -318,14 +318,19 @@ class TestTag(TestCase):
                 "tag_type": "example_tag_3",
                 "validate_tag_value": {"regex": r".*eduNEXT$"},
                 "validate_target_object": "CourseEnrollment",
-                "validate_expiration_date": {"exist": True, "in": ["Dec 04 2020 10:20:30", "Oct 19 2020 10:20:30"]},
-                "validate_activation_date": "Jun 16 2020 10:20:30"
+                "validate_expiration_date": {"exist": True, "between": ["2020-10-19 10:20:30", "2020-12-04 10:20:30"]},
+                "validate_activation_date": "2020-06-16 10:20:30",
             }]
     )
-    def test_validation_list_with_date(self):
-        """Used to test date validations."""
+    def test_validation_date_between(self):
+        """
+        Used to test date validations using BETWEEN validator.
+        This means that expiration_date must be grater or equal than "2020-10-19 10:20:30",
+        or less or equal than "2020-12-04 10:20:30".
+        """
         fake_object_target_enroll = CourseEnrollment.objects.create()  # pylint: disable=no-member
-        Tag.objects.create_tag(
+
+        tag = Tag.objects.create_tag(
             tag_value="example by eduNEXT",
             tag_type="example_tag_3",
             target_object=fake_object_target_enroll,
@@ -333,3 +338,87 @@ class TestTag(TestCase):
             expiration_date=datetime.datetime(2020, 10, 19, 10, 20, 30),
             activation_date=datetime.datetime(2020, 6, 16, 10, 20, 30),
         )
+
+        self.assertIsNotNone(tag.id)
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "example_tag_3",
+                "validate_tag_value": {"regex": r".*eduNEXT$"},
+                "validate_target_object": "CourseEnrollment",
+                "validate_expiration_date": {"exist": True, "between": ["2020-10-19 10:20:30", "2020-12-04 10:20:30"]},
+                "validate_activation_date": "2020-06-16 10:20:30",
+            }]
+    )
+    def test_validation_date_not_in_between(self):
+        """
+        Used to test date validations using BETWEEN validator. In this case, the validator must
+        raise a validation error because the date is not in between the two dates defined.
+        """
+        fake_object_target_enroll = CourseEnrollment.objects.create()  # pylint: disable=no-member
+
+        with self.assertRaises(ValidationError):
+            Tag.objects.create_tag(
+                tag_value="example by eduNEXT",
+                tag_type="example_tag_3",
+                target_object=fake_object_target_enroll,
+                owner_object=self.fake_owner_object,
+                expiration_date=datetime.datetime(2020, 5, 19, 10, 20, 30),
+                activation_date=datetime.datetime(2020, 6, 16, 10, 20, 30),
+            )
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "example_tag_3",
+                "validate_tag_value": {"regex": r".*eduNEXT$"},
+                "validate_target_object": "CourseEnrollment",
+                "validate_expiration_date": {"in": ["2020-12-04 10:20:30", "2020-10-19 10:20:30"]},
+                "validate_activation_date": "2020-06-16 10:20:30",
+            }]
+    )
+    def test_validation_date_in_list(self):
+        """
+        Used to test date validations using IN validator. This means that expiration_date bust be equal to
+        "2020-12-04 10:20:30" or equal to "2020-10-19 10:20:30".
+        """
+        fake_object_target_enroll = CourseEnrollment.objects.create()  # pylint: disable=no-member
+
+        tag = Tag.objects.create_tag(
+            tag_value="example by eduNEXT",
+            tag_type="example_tag_3",
+            target_object=fake_object_target_enroll,
+            owner_object=self.fake_owner_object,
+            expiration_date=datetime.datetime(2020, 10, 19, 10, 20, 30),
+            activation_date=datetime.datetime(2020, 6, 16, 10, 20, 30),
+        )
+
+        self.assertIsNotNone(tag.id)
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "example_tag_3",
+                "validate_tag_value": {"regex": r".*eduNEXT$"},
+                "validate_target_object": "CourseEnrollment",
+                "validate_expiration_date": {"in": ["2020-12-04 10:20:30", "2020-10-19 10:20:30"]},
+                "validate_activation_date": "2020-06-16 10:20:30",
+            }]
+    )
+    def test_validation_date_not_in_list(self):
+        """
+        Used to test date validations using IN validator. In this case, the validator must raise
+        a validation error because the date is different two those defined inside the array.
+        """
+        fake_object_target_enroll = CourseEnrollment.objects.create()  # pylint: disable=no-member
+
+        with self.assertRaises(ValidationError):
+            Tag.objects.create_tag(
+                tag_value="example by eduNEXT",
+                tag_type="example_tag_3",
+                target_object=fake_object_target_enroll,
+                owner_object=self.fake_owner_object,
+                expiration_date=datetime.datetime(2020, 4, 19, 10, 20, 30),
+                activation_date=datetime.datetime(2020, 6, 16, 10, 20, 30),
+            )


### PR DESCRIPTION
This PR depends on #14 

This PR adds DateTime validators like:

- BETWEEN: validates that the date is between two dates
For example:
In the configuration:
```
{
...
"validate_expiration_date": {"between": ["2020-10-19 10:20:30", "2020-12-04 10:20:30"]},
}
```
Now, we can only create tags where their expiration_date is greater than "2020-10-19 10:20:30" and less than "2020-12-04 10:20:30" (as date objects). The array must be sorted because it behaves like a range. Should we verify this when validating the settings? @andrey-canon 

- EQUALS: now compares two date objects

- IN: validates that the date as string is in the specified array

Also added API tests using different datetime formats