### PR TITLE
Fixed readonly_field name error

### DIFF
--- a/eox_tagging/admin.py
+++ b/eox_tagging/admin.py
@@ -24,7 +24,7 @@ class TagAdmin(admin.ModelAdmin):
         'target_as_nice_string',
         'status',
         'created_at',
-        'invalidated_at',
+        'inactivated_at',
     )
     search_fields = ('tag_type', 'tag_value', 'status')
 


### PR DESCRIPTION
This PR fixes a typing error in read_only fields after changing valid/invalid to active/inactive