### PR TITLE
Using - instead of _ for the urls namespace

### DIFF
--- a/eox_tagging/apps.py
+++ b/eox_tagging/apps.py
@@ -15,13 +15,13 @@ class EoxTaggingConfig(AppConfig):
     plugin_app = {
         'url_config': {
             'lms.djangoapp': {
-                'namespace': 'eox_tagging',
-                'regex': r'^eox_tagging/',
+                'namespace': 'eox-tagging',
+                'regex': r'^eox-tagging/',
                 'relative_path': 'urls',
             },
             'cms.djangoapp': {
-                'namespace': 'eox_tagging',
-                'regex': r'^eox_tagging/',
+                'namespace': 'eox-tagging',
+                'regex': r'^eox-tagging/',
                 'relative_path': 'urls',
             }
         },


### PR DESCRIPTION
Lets use the more standard namespace here.

@andrey-canon could you please check that this is also fixed at the cookiecutter?