### PR TITLE
Added safe method to get dictionary value in access filter

### DIFF
--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -96,7 +96,7 @@ class TagFilter(filters.FilterSet):
         """Filters targets by their access type."""
         if value:
             value_map = {v.lower(): k for k, v in AccessLevel.choices()}
-            value = value_map[value.lower()]
-            queryset = queryset.filter(access=value)
+            access = value_map.get(value.lower())
+            queryset = queryset.filter(access=access) if access else queryset.none()
 
         return queryset


### PR DESCRIPTION
This PR changes the access to the dictionary containing the values of the access filter. This way we can search using non-existent access values and the filter won't fail