### PR TITLE
Fix installation of test requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ requirements: ## install environment requirements
 	pip install -r requirements/base.txt
 
 test_requirements:
-	pip install -r requirements/test.txt
+	pip install -r requirements/test.txt -r requirements/django.txt
 
 docs_requirements:
 	pip install -r requirements/docs.txt


### PR DESCRIPTION
Install django version defined in django.txt when using `test_requirements` make target