### PR TITLE
Added datetime filters tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 ----------
 
 * The user can force a value in a field using the configuration.
+* Fixed datetime filters for activation_date and creation_date.
 
 [0.5.0] - 2020-07-14
 --------------------

--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -17,13 +17,13 @@ class TagFilter(filters.FilterSet):
     enrollments = filters.CharFilter(method="filter_enrollments")
     target_type = filters.CharFilter(method="filter_target_types")
     created_at = filters.DateTimeFromToRangeFilter(name="created_at")
-    activated_at = filters.DateTimeFromToRangeFilter(name="activated_at")
+    activation_date = filters.DateTimeFromToRangeFilter(name="activation_date")
     access = filters.CharFilter(method="filter_access_type")
 
     class Meta:  # pylint: disable=old-style-class
         """Meta class."""
         model = Tag
-        fields = ['key', 'created_at', 'activated_at', 'status', 'course_id', 'enrolled', 'enrollments', 'username']
+        fields = ['key', 'created_at', 'activation_date', 'status', 'course_id', 'enrolled', 'enrollments', 'username']
 
     def filter_by_target_object(self, queryset, name, value):
         """Filter that returns the tags associated with target."""


### PR DESCRIPTION
This PR adds tests for datetime filters

According to [this](https://django-filter.readthedocs.io/en/1.1.0/ref/filters.html?highlight=datetimefromtorangefilter#datetimefromtorangefilter ) the examples added are the correct way of using datetime filters

activation_date_0 is equivalent toactivation_date _after
activation_date_1 is equivalent to activation_date_before

Also, changes activated_at to activation_date which is the real name