### PR TITLE
Added force_<FIELD_NAME> to configurations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Change Log
 Unreleased
 ----------
 
-*
+* The user can force a value in a field using the configuration.
 
 [0.5.0] - 2020-07-14
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ Important notes:
   * If a key in the settings dictionary has as prefix `validate` it means that the <key, value> can have a dictionary of validations as value. If not, is assume that
       value is a string.
 
+* force_<FIELD_VALUE> meaning:
+
+    * This allows to set a value to a field without running validations or directly specifying it in the tag object.
+
 * The validations available are:
 
 +---------------+-------+-----------------------------------------------+----------------------------------------------------------------+

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -87,6 +87,21 @@ the program will assume that the field must be equal to the value. For example:
 
 This means that the FIELD with FIELD_NAME must be equal to VALUE.
 
+Setting values using the configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The configuration object can also be used to set TAG values. For example, if I want all the tags to have access level `PRIVATE`
+then I would do the following:
+
+In the configuration object:
+
+.. code-block:: JSON
+
+        {
+            "force_access": "PRIVATE"
+        }
+
+This helps to set constant values across tags without doing it explicitly while creating each one.
 
 Errors
 ------

--- a/eox_tagging/constants.py
+++ b/eox_tagging/constants.py
@@ -26,6 +26,14 @@ class AccessLevel(IntEnum):
                 return key.name
         return None
 
+    @classmethod
+    def get_access_object(cls, value):
+        """Function that given a key name returns an access object."""
+        for key in cls:  # pylint: disable=not-an-iterable, useless-suppression
+            if key.name.lower() == value.lower():
+                return key
+        return None
+
 
 class Status(IntEnum):
     """

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -4,6 +4,7 @@ Model to store tags in the database.
 import logging
 import re
 import uuid
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -192,6 +193,22 @@ class Tag(models.Model):
     def owner_object_type(self):
         """Obtain the name of the object which the tag belongs to."""
         return self.owner_object.__class__.__name__ if self.owner_object else None
+
+    def set_attribute(self, attr, value):
+        """Function that takes a value and sets it to the instance attribute."""
+        if attr == "access":
+            self.access = AccessLevel.get_access_object(value)
+            return
+
+        if attr == "activation_date":
+            self.activation_date = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            return
+
+        if attr == "expiration_date":
+            self.expiration_date = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            return
+
+        setattr(self, attr, value)
 
     def get_attribute(self, attr, name=False):
         """

--- a/eox_tagging/test/test_models.py
+++ b/eox_tagging/test/test_models.py
@@ -121,6 +121,94 @@ class TestTag(TestCase):
     @override_settings(
         EOX_TAGGING_DEFINITIONS=[
             {
+                "tag_type": "subscription_tier",
+                "force_access": "private",
+                "validate_tag_value": {"in": ["free", "private"]},
+                "validate_owner_object": "User",
+                "validate_target_object": "User",
+            },
+        ])
+    def test_force_access_configuration(self):
+        """
+        Used to test that if a field is `forced` then it must be set to the value
+        specified."""
+        tag = Tag.objects.create_tag(
+            tag_value="free",
+            tag_type="subscription_tier",
+            target_object=self.target_object,
+            owner_object=self.owner_object,
+        )
+
+        self.assertIsNotNone(tag.id)
+        self.assertEqual(tag.access.name, "PRIVATE")
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "subscription_tier",
+                "force_activation_date": "2020-10-19 10:20:30",
+                "validate_tag_value": {"in": ["free", "private"]},
+                "validate_owner_object": "User",
+                "validate_target_object": "User",
+            },
+        ])
+    def test_force_activation_date_configuration(self):
+        """Used to test that if a field is `forced` the must be set to the value specified."""
+        tag = Tag.objects.create_tag(
+            tag_value="free",
+            tag_type="subscription_tier",
+            target_object=self.target_object,
+            owner_object=self.owner_object,
+        )
+
+        self.assertIsNotNone(tag.id)
+        self.assertEqual(str(tag.activation_date), "2020-10-19 10:20:30")
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "subscription_tier",
+                "force_expiration_date": "2020-10-19 10:20:30",
+                "validate_tag_value": {"in": ["free", "private"]},
+                "validate_owner_object": "User",
+                "validate_target_object": "User",
+            },
+        ])
+    def test_force_expiration_date_configuration(self):
+        """Used to test that if a field is `forced` the must be set to the value specified."""
+        tag = Tag.objects.create_tag(
+            tag_value="free",
+            tag_type="subscription_tier",
+            target_object=self.target_object,
+            owner_object=self.owner_object,
+        )
+
+        self.assertIsNotNone(tag.id)
+        self.assertEqual(str(tag.expiration_date), "2020-10-19 10:20:30")
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
+                "tag_type": "subscription_tier",
+                "force_tag_value": "free",
+                "validate_owner_object": "User",
+                "validate_target_object": "User",
+            },
+        ])
+    def test_force_tag_value_configuration(self):
+        """Used to test that if a field is `forced` the must be set to the value specified."""
+        tag = Tag.objects.create_tag(
+            tag_type="subscription_tier",
+            target_object=self.target_object,
+            owner_object=self.owner_object,
+        )
+
+        self.assertIsNotNone(tag.id)
+        self.assertEqual(tag.tag_value, "free")
+
+    @override_settings(
+        EOX_TAGGING_DEFINITIONS=[
+            {
                 "tag_type": "example_tag_7",
                 "validate_owner_object": "User",
                 "validate_access": {"equals": "PRIVATE"},
@@ -236,7 +324,7 @@ class TestTag(TestCase):
                 expiration_date=datetime.date(2020, 10, 19),
             )
 
-    def test_tag_inmutable(self):
+    def test_tag_immutable(self):
         """ Used to confirm that the tags can't be updated."""
         setattr(self.test_tag, "tag_value", "value")
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Now using the configuration object the user will be able to set tag values. For example, if I want to set a specific access level without specifying it while creating each tag, then I will add to EOX_TAGGING_DEFINITIONS the following:

`{"force_access": "PRIVATE"}`