### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,6 @@ jobs:
       - restore_cache:
           keys:
           - test-tox-py<< parameters.python_version >>-<< parameters.django_version >>-{{ checksum "requirements/test.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - test-tox-py<< parameters.python_version >>-<< parameters.django_version >>-
 
       - run:
           name: activate virtualenv and install dependencies.

--- a/eox_tagging/api/v1/test/test_routers.py
+++ b/eox_tagging/api/v1/test/test_routers.py
@@ -1,28 +1,12 @@
 """
 Test classes for Tags router
 """
-from django.conf.urls import include, url
 from django.test import TestCase
 from django.urls import reverse
-from rest_framework.routers import DefaultRouter
-from rest_framework.test import URLPatternsTestCase
-
-from eox_tagging.api.v1.viewset import TagViewSet
 
 
-class TestRouters(URLPatternsTestCase, TestCase):
+class TestRouters(TestCase):
     """Test class for API router."""
-
-    router = DefaultRouter()
-    router.register(r"tags", TagViewSet, basename='tag')
-
-    urlpatterns = [
-        url(r"api/v1/", include(router.urls)),
-    ]
-
-    def setUp(self):
-        """Router setup."""
-        self.router = DefaultRouter()
 
     def test_get_route_for_list_tags(self):
         """Used to test correctness of list route."""


### PR DESCRIPTION
## Description 
This removes nonexistent tests dependencies, theses tests  only verify the returned value by the reverse, I don't understand why the setup and other things and necessary @mariajgrimaldi 

This happened due to this line https://github.com/eduNEXT/eox-tagging/blob/master/.circleci/config.yml#L51 since this allowed to use a  different version of djangorestframework and the new version was installed after the cache deletion, @morenol  do we need that ???