### PR TITLE
Fixed case sensitive issue in serializer

### DIFF
--- a/eox_tagging/api/v1/serializers.py
+++ b/eox_tagging/api/v1/serializers.py
@@ -67,10 +67,10 @@ class TagSerializer(serializers.ModelSerializer):
         try:
             target_object = get_object(target_type, **data)
         except Exception:  # pylint: disable=broad-except
-            serializers.ValidationError({"Target": _("Error getting {} object."
-                                         .format(target_type))})
+            raise serializers.ValidationError({"Target": _("Error getting {} object."
+                                               .format(target_type))})
 
-        if owner_type == "user":
+        if owner_type and owner_type.lower() == "user":
             owner_object = self.context.get("request").user
         else:
             owner_object = get_site()

--- a/eox_tagging/edxapp_accessors.py
+++ b/eox_tagging/edxapp_accessors.py
@@ -64,7 +64,7 @@ def get_object(related_object_type, **kwargs):
         "courseenrollment": get_course_enrollment,
     }
     try:
-        related_object = RELATED_OBJECTS.get(related_object_type)(**kwargs)
+        related_object = RELATED_OBJECTS.get(related_object_type.lower())(**kwargs)
     except Exception:
         raise ValidationError("This field is required.")
 


### PR DESCRIPTION
In the serializer, we received target_object/owner_object and it was case sensitive (my error)