### PR TITLE
Fix error 500 when getting tags

### DIFF
--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -11,19 +11,19 @@ PROXY_MODEL_NAME = "opaquekeyproxymodel"
 class TagFilter(filters.FilterSet):
     """Filter class for tags."""
 
-    course_id = filters.CharFilter(field_name="course_id", method="filter_by_target_object")
-    username = filters.CharFilter(field_name="username", method="filter_by_target_object")
-    enrolled = filters.CharFilter(field_name="enrollment", method="filter_by_target_object")
+    course_id = filters.CharFilter(method="filter_by_target_object")
+    username = filters.CharFilter(method="filter_by_target_object")
+    enrollment = filters.CharFilter(method="filter_by_target_object")
     enrollments = filters.CharFilter(method="filter_enrollments")
     target_type = filters.CharFilter(method="filter_target_types")
-    created_at = filters.DateTimeFromToRangeFilter(field_name="created_at")
-    activation_date = filters.DateTimeFromToRangeFilter(field_name="activation_date")
+    created_at = filters.DateTimeFromToRangeFilter()
+    activation_date = filters.DateTimeFromToRangeFilter()
     access = filters.CharFilter(method="filter_access_type")
 
     class Meta:  # pylint: disable=old-style-class, useless-suppression
         """Meta class."""
         model = Tag
-        fields = ['key', 'created_at', 'activation_date', 'status', 'course_id', 'enrolled', 'enrollments', 'username']
+        fields = ['key', 'status']
 
     def filter_by_target_object(self, queryset, name, value):
         """Filter that returns the tags associated with target."""


### PR DESCRIPTION
This PR fixes the following error in Ironwood:

Part of the traceback
```
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django_filters/fields.py", line 64, in __init__
    super(DateTimeRangeField, self).__init__(fields, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django_filters/fields.py", line 25, in __init__
    super(RangeField, self).__init__(fields, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/forms/fields.py", line 996, in __init__
    super(MultiValueField, self).__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'field_name'
```

This happens because depending on the django_filters version `field_name` or `name` is used. In PR #47 I changed `name` to `field_name` for the tests to pass, and with this error, I decided to remove the field.

In any case, according to the documentation: 

> By default, if field_name is not specified, the filter's name on the filterset class will be used.

So, in general, the filters stay the same.

