### PR TITLE
Fix enrollment filter

### DIFF
--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -1,5 +1,4 @@
 """Filter module for tags."""
-from django.contrib.contenttypes.models import ContentType
 from django_filters import rest_framework as filters
 
 from eox_tagging.constants import AccessLevel
@@ -13,8 +12,7 @@ class TagFilter(filters.FilterSet):
 
     course_id = filters.CharFilter(method="filter_by_target_object")
     username = filters.CharFilter(method="filter_by_target_object")
-    enrollment = filters.CharFilter(method="filter_by_target_object")
-    enrollments = filters.CharFilter(method="filter_enrollments")
+    enrollments = filters.CharFilter(method="filter_by_target_object")
     target_type = filters.CharFilter(method="filter_target_types")
     created_at = filters.DateTimeFromToRangeFilter()
     activation_date = filters.DateTimeFromToRangeFilter()
@@ -48,26 +46,6 @@ class TagFilter(filters.FilterSet):
                     "target_id": TARGET_IDENTIFICATION.get(name, DEFAULT),
                 }
                 queryset = queryset.find_all_tags_for(**filter_params)
-            except Exception:  # pylint: disable=broad-except
-                return queryset.none()
-
-        return queryset
-
-    def filter_enrollments(self, queryset, name, value):  # pylint: disable=unused-argument
-        """Filter that returns the tags associated with the enrollments owned by the request user."""
-        if value:
-            try:
-                ctype = ContentType.objects.get(model="courseenrollment")
-                enrollments_queryset = queryset.find_all_tags_by_type("courseenrollment")
-
-                query_enrollments = []
-                for tag_enrollment in enrollments_queryset:
-                    target_id = tag_enrollment.target_object_id
-                    enrollment = ctype.get_object_for_this_type(id=target_id)
-                    if str(enrollment.course_id) == str(value):
-                        query_enrollments.append(tag_enrollment)
-
-                return query_enrollments
             except Exception:  # pylint: disable=broad-except
                 return queryset.none()
 

--- a/eox_tagging/api/v1/serializers.py
+++ b/eox_tagging/api/v1/serializers.py
@@ -57,7 +57,7 @@ class TagSerializer(serializers.ModelSerializer):
         owner_type = validated_data.pop("owner_object_type", None)
         target = validated_data.pop("target_object", None)
 
-        if target_type in MODELS_WITH_COMPOUND_KEYS:
+        if target_type and target_type.lower() in MODELS_WITH_COMPOUND_KEYS:
             data = self.__convert_compound_keys(target, target_type)
         else:
             data = {

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -28,6 +28,8 @@ OPAQUE_KEY_PROXY_MODEL_TARGETS = [
 
 PROXY_MODEL_NAME = "opaquekeyproxymodel"
 
+COURSE_ENROLLMENT_MODEL_NAME = "courseenrollment"
+
 
 class TagQuerySet(QuerySet):
     """ Tag queryset used as manager."""
@@ -93,6 +95,13 @@ class TagQuerySet(QuerySet):
             object_id = {
                 "opaque_key": CourseKey.from_string(object_id),
             }
+
+        if object_type == COURSE_ENROLLMENT_MODEL_NAME:
+            object_id = {
+                "course_id": CourseKey.from_string(object_id.get("course_id")),
+                "user__username": object_id.get("username"),
+            }
+
         object_instance = ctype.get_object_for_this_type(**object_id)
 
         return object_instance, ctype


### PR DESCRIPTION
There were two filters for enrollments:

- The one called `enrollment`
- The one called `enrollments`

The first one was using a method called `filter_by_target_object` and it was not working.
The second one was using a method called `filter_enrollment` and it was working. But that method was redundant given that we had `filter_by_target_object`.

What I did was:
- Fixing `filter_by_target_object` so it could work with enrollments (as it should be)
- Deleted `filter_enrollment` and `enrollments` filter
- Changed `enrollment` for  `enrollments`, so the filter can be used in the same way as before.

