### PR TITLE
JU: Fix not loading correct settings when testing

### DIFF
--- a/eox_tagging/settings/test.py
+++ b/eox_tagging/settings/test.py
@@ -45,16 +45,20 @@ USE_TZ = True
 
 ALLOWED_HOSTS = ['*']
 
-EOX_TAGGING_SKIP_VALIDATIONS = True
-EOX_TAGGING_LOAD_PERMISSIONS = False
-EOX_TAGGING_BEARER_AUTHENTICATION = 'eox_tagging.edxapp_wrappers.backends.bearer_authentication_i_v1_test'
-DATA_API_DEF_PAGE_SIZE = 1000
-DATA_API_MAX_PAGE_SIZE = 5000
-TEST_SITE = 1
 
-
-def plugin_settings(settings):  # pylint: disable=function-redefined, unused-argument
+def plugin_settings(settings):  # pylint: disable=function-redefined
     """
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
+    settings.EOX_TAGGING_SKIP_VALIDATIONS = True
+    settings.EOX_TAGGING_LOAD_PERMISSIONS = False
+    settings.EOX_TAGGING_BEARER_AUTHENTICATION = 'eox_tagging.edxapp_wrappers.backends.bearer_authentication_i_v1_test'
+    settings.DATA_API_DEF_PAGE_SIZE = 1000
+    settings.DATA_API_MAX_PAGE_SIZE = 5000
+    settings.TEST_SITE = 1
+
+
+SETTINGS = SettingsClass()
+plugin_settings(SETTINGS)
+vars().update(SETTINGS.__dict__)


### PR DESCRIPTION
This PR fixes [this](https://app.circleci.com/pipelines/github/eduNEXT/edunext-platform/1220/workflows/a5be70d9-adfd-4470-b2e7-8e76c69f0ffc/jobs/8093) error in `lms_unit_test`.

It was happening because when loading plugin settings from settings/test.py the function `plugin_settings` was empty, so this setting `EOX_TAGGING_LOAD_PERMISSIONS` didn't have the correct value used when testing.

