### PR TITLE
FIxed API permissions error using DOT

### DIFF
--- a/eox_tagging/api/v1/permissions.py
+++ b/eox_tagging/api/v1/permissions.py
@@ -37,15 +37,23 @@ class EoxTaggingAPIPermission(permissions.BasePermission):
         """
         To grant access, checks if the requesting user either can call eox-tagging API or if it's an admin user.
         """
+        if request.user.is_staff:
+            return True
+
         try:
-            allowed_for_site = request.user.is_staff or request.get_host() in request.auth.client.url
+            application_uri_allowed = request.auth.application.redirect_uri_allowed(request.build_absolute_uri('/'))
         except Exception:  # pylint: disable=broad-except
-            allowed_for_site = False
+            application_uri_allowed = False
 
-        if not allowed_for_site:
-            # If we get here either someone is using a token created on one site in a different site
-            # or there was a missconfiguration of the oauth client.
-            # To prevent leaking important information we return the most basic message.
-            raise exceptions.NotAuthenticated(detail="Invalid token")
+        try:
+            client_url_allowed = request.get_host() in request.auth.client.url
+        except Exception:  # pylint: disable=broad-except
+            client_url_allowed = False
 
-        return request.user.has_perm('auth.can_call_eox_tagging') or request.user.is_staff
+        if client_url_allowed or application_uri_allowed:
+            return request.user.has_perm('auth.can_call_eox_tagging')
+
+        # If we get here either someone is using a token created on one site in a different site
+        # or there was a missconfiguration of the oauth client.
+        # To prevent leaking important information we return the most basic message.
+        raise exceptions.NotAuthenticated(detail="Invalid token")

--- a/eox_tagging/api/v1/test/test_permissions.py
+++ b/eox_tagging/api/v1/test/test_permissions.py
@@ -53,6 +53,7 @@ class TestAPIPermissions(TestCase):
         self.mock_request.get_host.return_value = "test_.com"
         self.mock_request.user = self.user_authorized
         self.mock_request.auth.client.url = "test.com"
+        self.mock_request.auth.application.redirect_uri_allowed.return_value = False
 
         with self.assertRaises(exceptions.NotAuthenticated):
             self.has_permission(self.mock_request, self.view)
@@ -62,6 +63,7 @@ class TestAPIPermissions(TestCase):
         self.mock_request.get_host.return_value = None
         self.mock_request.user = self.user_authorized
         self.mock_request.auth.client.url = "test.com"
+        self.mock_request.auth.application.redirect_uri_allowed.return_value = False
 
         with self.assertRaises(exceptions.NotAuthenticated):
             self.has_permission(self.mock_request, self.view)
@@ -71,6 +73,7 @@ class TestAPIPermissions(TestCase):
         self.mock_request.get_host.return_value = "test_.com"
         self.mock_request.user = self.user_authorized
         self.mock_request.auth.client.url = None
+        self.mock_request.auth.application.redirect_uri_allowed.return_value = False
 
         with self.assertRaises(exceptions.NotAuthenticated):
             self.has_permission(self.mock_request, self.view)


### PR DESCRIPTION
This update was taken from https://github.com/eduNEXT/eox-core/blob/master/eox_core/api/v1/permissions.py