### PR TITLE
Fix courseenrollment filters and refactor

### DIFF
--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -53,9 +53,22 @@ class TagFilter(filters.FilterSet):
 
     def filter_target_types(self, queryset, name, value):  # pylint: disable=unused-argument
         """Filter that returns targets by their type."""
+        target_id = {}
+
+        if value == "courseenrollment":
+            course_id = self.request.query_params.get("enrollment_course_id")
+            username = self.request.query_params.get("enrollment_username")
+            target_id.update({"username": username, "course_id": course_id})
+
+        if any(object_id for _, object_id in target_id.items()):
+            try:
+                return queryset.find_all_tags_for(target_type=value, target_id=target_id)
+            except Exception:  # pylint: disable=broad-except
+                return queryset.none()
+
         if value:
             try:
-                queryset = queryset.find_all_tags_by_type(str(value))
+                queryset = queryset.find_all_tags_by_type(value)
             except Exception:  # pylint: disable=broad-except
                 return queryset.none()
 

--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -12,38 +12,31 @@ class TagFilter(filters.FilterSet):
 
     course_id = filters.CharFilter(method="filter_by_target_object")
     username = filters.CharFilter(method="filter_by_target_object")
-    enrollments = filters.CharFilter(method="filter_by_target_object")
     target_type = filters.CharFilter(method="filter_target_types")
     created_at = filters.DateTimeFromToRangeFilter()
     activation_date = filters.DateTimeFromToRangeFilter()
+    expiration_date = filters.DateTimeFromToRangeFilter()
     access = filters.CharFilter(method="filter_access_type")
 
     class Meta:  # pylint: disable=old-style-class, useless-suppression
         """Meta class."""
         model = Tag
-        fields = ['key', 'status']
+        fields = ["key", "status", "tag_type", "tag_value"]
 
     def filter_by_target_object(self, queryset, name, value):
         """Filter that returns the tags associated with target."""
         TARGET_TYPES = {
             "course_id": "courseoverview",
             "username": "user",
-            "enrollment": "courseenrollment",
         }
         if value:
-            TARGET_IDENTIFICATION = {
-                "enrollment": {
-                    "username": self.request.user.username,
-                    "course_id": str(value),
-                },
-            }
             DEFAULT = {
-                name: str(value),
+                name: value,
             }
             try:
                 filter_params = {
                     "target_type": TARGET_TYPES.get(name),
-                    "target_id": TARGET_IDENTIFICATION.get(name, DEFAULT),
+                    "target_id": DEFAULT,
                 }
                 queryset = queryset.find_all_tags_for(**filter_params)
             except Exception:  # pylint: disable=broad-except

--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -45,7 +45,19 @@ class TagFilter(filters.FilterSet):
         return queryset
 
     def filter_target_types(self, queryset, name, value):  # pylint: disable=unused-argument
-        """Filter that returns targets by their type."""
+        """
+        Filter that returns targets using their type.
+
+        **SPECIAL CASE**: course enrollments.
+
+        If the user wants to filter by target_type courseenrollment and wants to add filters on
+        user or course, it must pass the following:
+
+            - target_type: if the other arguments are passed this is used to differentiate between
+            course_id from courseoverview and username from user object.
+            - enrollment_course_id (optional)
+            - enrollment_username (optional)
+        """
         target_id = {}
 
         if value == "courseenrollment":
@@ -53,17 +65,13 @@ class TagFilter(filters.FilterSet):
             username = self.request.query_params.get("enrollment_username")
             target_id.update({"username": username, "course_id": course_id})
 
-        if any(object_id for _, object_id in target_id.items()):
-            try:
-                return queryset.find_all_tags_for(target_type=value, target_id=target_id)
-            except Exception:  # pylint: disable=broad-except
-                return queryset.none()
-
-        if value:
-            try:
+        try:
+            if any(object_id for object_id in target_id.values()):
+                queryset = queryset.find_all_tags_for(target_type=value, target_id=target_id)
+            elif value:
                 queryset = queryset.find_all_tags_by_type(value)
-            except Exception:  # pylint: disable=broad-except
-                return queryset.none()
+        except Exception:  # pylint: disable=broad-except
+            return queryset.none()
 
         return queryset
 

--- a/eox_tagging/api/v1/serializers.py
+++ b/eox_tagging/api/v1/serializers.py
@@ -26,7 +26,7 @@ class TagSerializer(serializers.ModelSerializer):
     owner_type = serializers.CharField(source='owner_object_type', write_only=True, required=False)
     target_type = serializers.CharField(source='target_object_type', write_only=True)
     meta = serializers.SerializerMethodField()
-    access = fields.EnumField(enum=AccessLevel)
+    access = fields.EnumField(enum=AccessLevel, required=False)
     status = fields.EnumField(enum=Status, required=False)
 
     class Meta:  # pylint: disable=old-style-class, useless-suppression

--- a/eox_tagging/api/v1/test/test_filters.py
+++ b/eox_tagging/api/v1/test/test_filters.py
@@ -1,0 +1,94 @@
+""" Test classes for Tags filters. """
+
+from django.test import TestCase
+from mock import Mock, patch
+
+from eox_tagging.api.v1.filters import TagFilter
+from eox_tagging.models import Tag
+
+
+class FilterTest(TestCase):
+    """Test class for custom filters."""
+
+    def setUp(self):
+        """setUp class."""
+        self.filterset = TagFilter()
+        self.filterset.request = Mock()
+
+    @patch.object(Tag, 'objects')
+    def test_filter_by_target_object(self, objects_mock):
+        """Used to test filtering tags by target object."""
+        objects_mock.find_all_tags_for = Mock()
+        name = "username"
+        value = "test"
+
+        self.filterset.filter_by_target_object(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type="user",
+            target_id={name: value},
+        )
+
+    @patch.object(Tag, 'objects')
+    def test_filter_target_enrollment(self, objects_mock):
+        """
+        Used to test filtering tags depending on the target type. This also filters courseenrollments
+        given that we must specify the target type besides the other filter parameters, in this case
+        course_id and username.
+        """
+        objects_mock.find_all_tags_for = Mock()
+        value = "courseenrollment"
+        name = "target_type"
+        self.filterset.request.query_params = {
+            "enrollment_course_id": "course_id",
+            "enrollment_username": "username",
+        }
+
+        self.filterset.filter_target_types(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type=value,
+            target_id={"username": "username", "course_id": "course_id"},
+        )
+
+    @patch.object(Tag, 'objects')
+    def test_filter_target_enroll_by_user(self, objects_mock):
+        """
+        Used to test filtering tags depending on the target type. This also filters courseenrollments
+        given that we must specify the target type besides the other filter parameters, in this case
+        username.
+        """
+        objects_mock.find_all_tags_for = Mock()
+        value = "courseenrollment"
+        name = "target_type"
+        self.filterset.request.query_params = {
+            "enrollment_username": "username",
+        }
+
+        self.filterset.filter_target_types(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type=value,
+            target_id={"username": "username", "course_id": None},
+        )
+
+    @patch.object(Tag, 'objects')
+    def test_filter_target_enroll_by_course(self, objects_mock):
+        """
+        Used to test filtering tags depending on the target type. This also filters courseenrollments
+        given that we must specify the target type besides the other filter parameters, in this case
+        course_id.
+        """
+        objects_mock.find_all_tags_for = Mock()
+        value = "courseenrollment"
+        name = "target_type"
+        self.filterset.request.query_params = {
+            "enrollment_course_id": "course_id",
+        }
+
+        self.filterset.filter_target_types(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type=value,
+            target_id={"username": None, "course_id": "course_id"},
+        )

--- a/eox_tagging/api/v1/test/test_viewset.py
+++ b/eox_tagging/api/v1/test/test_viewset.py
@@ -147,6 +147,7 @@ class TestTagViewSet(TestCase):
         }
 
         response = self.client.post(self.URL, data, format='json')
+
         owner_type = response.data.get("meta").get("owner_type")
         self.assertEqual(owner_type, "Site")
 
@@ -190,7 +191,6 @@ class TestTagViewSet(TestCase):
     @patch_permissions
     def test_create_tag_with_owner_site(self, _):
         """"Used to test creating a tag with site as owner."""
-
         data = {
             "tag_type": "example_tag_2",
             "tag_value": "example_tag_value",
@@ -202,6 +202,7 @@ class TestTagViewSet(TestCase):
         }
 
         response = self.client.post(self.URL, data, format='json')
+
         owner_type = response.data.get("meta").get("owner_type").lower()
         self.assertEqual(owner_type, "site")
 
@@ -389,9 +390,9 @@ class TestTagViewSet(TestCase):
         self.assertTrue(all(datetimes))
 
     @patch_permissions
-    def test_filter_using_before_datetime(self, _):
+    def test_activation_using_before_filter(self, _):
         """
-        Used to test filtering tags using a range datetime filter. In this case, the filter is
+        Used to test filtering tags using a range datetime filter on activation date. In this case, the filter is
         after a specific datetime.
         """
         query_params = {
@@ -404,9 +405,29 @@ class TestTagViewSet(TestCase):
         response = self.client.get(self.URL, query_params)
 
         results = response.json().get("results")
-        datetimes = [datetime.datetime.strptime(tag.get("activation_date"), datetime_format) < datetime_value
-                     for tag in results]
-        self.assertTrue(all(datetimes))
+        activation_date = [datetime.datetime.strptime(tag.get("activation_date"), datetime_format) < datetime_value
+                           for tag in results]
+        self.assertTrue(all(activation_date))
+
+    @patch_permissions
+    def test_expiration_using_before_filter(self, _):
+        """
+        Used to test filtering tags using a range datetime filter on expiration date. In this case, the filter is
+        after a specific datetime.
+        """
+        query_params = {
+            "expiration_date_before": "2020-10-10 10:20:30",
+            "expiration_date_1": "2020-10-10 10:20:30",
+        }
+        datetime_value = datetime.datetime(2020, 10, 10, 10, 20, 30)
+        datetime_format = "%Y-%m-%dT%H:%M:%SZ"
+
+        response = self.client.get(self.URL, query_params)
+
+        results = response.json().get("results")
+        expiration_date = [datetime.datetime.strptime(tag.get("expiration_date"), datetime_format) < datetime_value
+                           for tag in results]
+        self.assertTrue(all(expiration_date))
 
     @patch_permissions
     def test_soft_delete(self, _):

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -90,7 +90,10 @@ class TagQuerySet(QuerySet):
         return super(TagQuerySet, self).delete()
 
     def __get_object_for_this_type(self, object_type, object_id):
-        """Function that returns the correct content type given a type."""
+        """
+        Function that given an object type returns the correct content type and a list of objects
+        associated.
+        """
         ctype = ContentType.objects.get(model=object_type)
 
         if object_type == PROXY_MODEL_NAME:
@@ -100,15 +103,16 @@ class TagQuerySet(QuerySet):
             }
 
         if object_type == COURSE_ENROLLMENT_MODEL_NAME:
+
             course_id = object_id.get("course_id")
-            object_id = {
-                name: value for name, value in
-                (
-                    ("course_id", CourseKey.from_string(course_id) if course_id else None),
-                    ("user__username", object_id.get("username")),
-                )
-                if value is not None
-            }
+            username = object_id.get("username")
+            object_id = {}
+
+            if course_id:
+                object_id["course_id"] = CourseKey.from_string(course_id)
+
+            if username:
+                object_id["user__username"] = username
 
         object_instances = ctype.get_all_objects_for_this_type(**object_id)
 

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -38,7 +38,7 @@ class TagQuerySet(QuerySet):
         """Method used to create tags."""
         target = kwargs.pop("target_object", None)
         if target and target.__class__.__name__ in OPAQUE_KEY_PROXY_MODEL_TARGETS:
-            kwargs['target_object'], _ = OpaqueKeyProxyModel.objects.get_or_create(opaque_key=target.id)
+            kwargs["target_object"], _ = OpaqueKeyProxyModel.objects.get_or_create(opaque_key=target.id)
         else:
             kwargs["target_object"] = target
         instance = self.create(**kwargs)

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -59,13 +59,14 @@ class TagQuerySet(QuerySet):
 
     def find_by_owner(self, owner_type, owner_id):
         """Returns all tags owned by owner_id."""
-
         try:
             owner, ctype = self.__get_object_for_this_type(owner_type, owner_id)
         except ObjectDoesNotExist:
             return self.none()
 
-        return self.filter(owner_type=ctype, owner_object_id=owner.id,)
+        owner_ids = list(owner.values_list("id", flat=True))
+
+        return self.filter(owner_type=ctype, owner_object_id__in=owner_ids)
 
     def find_all_tags_for(self, target_type, target_id):
         """Returns all tags defined on an object."""
@@ -76,7 +77,9 @@ class TagQuerySet(QuerySet):
         except ObjectDoesNotExist:
             return self.none()
 
-        return self.filter(target_type=ctype, target_object_id=target.id,)
+        target_ids = list(target.values_list("id", flat=True))
+
+        return self.filter(target_type=ctype, target_object_id__in=target_ids)
 
     def find_all_tags_by_type(self, object_type):
         """Returns all tags with target_type equals to object_type."""
@@ -97,14 +100,19 @@ class TagQuerySet(QuerySet):
             }
 
         if object_type == COURSE_ENROLLMENT_MODEL_NAME:
+            course_id = object_id.get("course_id")
             object_id = {
-                "course_id": CourseKey.from_string(object_id.get("course_id")),
-                "user__username": object_id.get("username"),
+                name: value for name, value in
+                (
+                    ("course_id", CourseKey.from_string(course_id) if course_id else None),
+                    ("user__username", object_id.get("username")),
+                )
+                if value is not None
             }
 
-        object_instance = ctype.get_object_for_this_type(**object_id)
+        object_instances = ctype.get_all_objects_for_this_type(**object_id)
 
-        return object_instance, ctype
+        return object_instances, ctype
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
This PR does the following:

1. Before these changes, courseenrollments were filtered using the course_id passed as a parameter and the user found in request.user. It didn't accept the user from query params. Now, we can filter courseenrollments passing course_id or user or neither. For example:

Option 1 (Returns tags on enrollments filtered by course_id and username): 
`?target_type=courseenrollment&enrollment_course_id=course-v1:edX%2BDemoX%2BDemo_Course&enrollment_username=edx`

Option 2 (Returns tags on enrollments filtered by course_id): 
`?target_type=courseenrollment&enrollment_course_id=course-v1:edX%2BDemoX%2BDemo_Course`

Option 3 (Returns tags on enrollments filtered by username):
 `?target_type=courseenrollment&enrollment_username=edx`

Option 4 (Returns all tags on enrollments): `
?target_type=courseenrollment`

2. Added Date filter for expiration_date

3. Added exact filter for tag_value, tag_type

4. Removed enrollments filter given point 1.

5. Added tests for new filters