### PR TITLE
Add eox-audit-model and drop support for Ironwood

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,8 @@ workflows:
               only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
-              python_version: ["2.7", "3.5"]
-              django_version: ["django111", "django22"]
-            exclude:
-              - python_version: "2.7"
-                django_version: "django22"
+              python_version: ["3.5"]
+              django_version: ["django22"]
       - pypi:
           requires:
             - test

--- a/eox_tagging/admin.py
+++ b/eox_tagging/admin.py
@@ -41,7 +41,7 @@ class TagAdmin(admin.ModelAdmin):
         """
         Custom search to support searching on the tagged objects
         """
-        queryset, use_distinct = super(TagAdmin, self).get_search_results(
+        queryset, use_distinct = super().get_search_results(
             request,
             queryset,
             search_term
@@ -71,7 +71,7 @@ class TagAdmin(admin.ModelAdmin):
         except Exception as error:
             return str(error)
 
-    def add_view(self, request, *args, **kwargs):  # pylint: disable=arguments-differ
+    def add_view(self, request, form_url='', extra_context=None):
         """
         Custom method to handle the specific case of tagging course_keys
 
@@ -106,7 +106,7 @@ class TagAdmin(admin.ModelAdmin):
             request.POST['target_type'] = ContentType.objects.get(model='OpaqueKeyProxyModel').id
             request.POST['target_object_id'] = opaque_key_proxy.id
 
-        return super(TagAdmin, self).add_view(request, *args, **kwargs)
+        return super().add_view(request, form_url='', extra_context=None)
 
 
 admin.site.register(Tag, TagAdmin)

--- a/eox_tagging/api/v1/filters.py
+++ b/eox_tagging/api/v1/filters.py
@@ -18,7 +18,7 @@ class TagFilter(filters.FilterSet):
     expiration_date = filters.DateTimeFromToRangeFilter()
     access = filters.CharFilter(method="filter_access_type")
 
-    class Meta:  # pylint: disable=old-style-class, useless-suppression
+    class Meta:
         """Meta class."""
         model = Tag
         fields = ["key", "status", "tag_type", "tag_value"]

--- a/eox_tagging/api/v1/serializers.py
+++ b/eox_tagging/api/v1/serializers.py
@@ -29,7 +29,7 @@ class TagSerializer(serializers.ModelSerializer):
     access = fields.EnumField(enum=AccessLevel, required=False)
     status = fields.EnumField(enum=Status, required=False)
 
-    class Meta:  # pylint: disable=old-style-class, useless-suppression
+    class Meta:
         """Meta class."""
         model = Tag
         fields = ('meta', 'key', 'tag_value', 'tag_type', 'access', 'activation_date', 'expiration_date',

--- a/eox_tagging/edxapp_wrappers/backends/bearer_authentication_i_v1_test.py
+++ b/eox_tagging/edxapp_wrappers/backends/bearer_authentication_i_v1_test.py
@@ -9,7 +9,7 @@ def get_bearer_authentication():
         BearerAuthentication function.
     """
     try:
-        from openedx.core.lib.api.authentication import BearerAuthentication
+        from openedx.core.lib.api.authentication import BearerAuthentication  # pylint: disable=import-outside-toplevel
     except ImportError:
         BearerAuthentication = object
     return BearerAuthentication

--- a/eox_tagging/edxapp_wrappers/backends/course_overview_i_v1.py
+++ b/eox_tagging/edxapp_wrappers/backends/course_overview_i_v1.py
@@ -7,7 +7,7 @@ openedx.core.djangoapps.content.course_overviews.
 def get_course_overview():
     """Backend to get course overview."""
     try:
-        from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+        from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-outside-toplevel
     except ImportError:
         CourseOverview = object
     return CourseOverview

--- a/eox_tagging/edxapp_wrappers/backends/enrollment_i_v1.py
+++ b/eox_tagging/edxapp_wrappers/backends/enrollment_i_v1.py
@@ -7,7 +7,7 @@ objects.
 def get_enrollment_object():
     """Backend to get enrollment object."""
     try:
-        from student.models import CourseEnrollment
+        from student.models import CourseEnrollment  # pylint: disable=import-outside-toplevel
     except ImportError:
         CourseEnrollment = object
     return CourseEnrollment

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -201,14 +201,14 @@ class Tag(models.Model):
 
     objects = TagQuerySet().as_manager()
 
-    class Meta:  # pylint: disable=old-style-class, useless-suppression
+    class Meta:
         """Meta class. """
         verbose_name = "tag"
         verbose_name_plural = "tags"
         app_label = "eox_tagging"
 
     def __str__(self):
-        return self.tag_value
+        return str(self.tag_value)
 
     @property
     def target_object_type(self):
@@ -308,15 +308,15 @@ class Tag(models.Model):
         self.clean()
         self.clean_fields()
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         self.full_clean()
-        super(Tag, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def delete(self):  # pylint: disable=arguments-differ
         self.inactivated_at = timezone.now()
         self.status = Status.INACTIVE
-        super(Tag, self).save()
+        super().save()
 
     def hard_delete(self):
         """Deletes object from database."""
-        super(Tag, self).delete()
+        super().delete()

--- a/eox_tagging/settings/common.py
+++ b/eox_tagging/settings/common.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'rest_framework',
+    'eox_audit_model.apps.EoxAuditModelConfig',
     'eox_tagging',
 ]
 

--- a/eox_tagging/settings/production.py
+++ b/eox_tagging/settings/production.py
@@ -9,4 +9,3 @@ def plugin_settings(settings):  # pylint: disable=unused-argument
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    pass

--- a/eox_tagging/settings/test.py
+++ b/eox_tagging/settings/test.py
@@ -6,10 +6,8 @@ from __future__ import unicode_literals
 from .common import *  # pylint: disable=wildcard-import
 
 
-class SettingsClass(object):
+class SettingsClass:
     """ dummy settings class """
-
-    pass
 
 
 SETTINGS = SettingsClass()

--- a/eox_tagging/validators.py
+++ b/eox_tagging/validators.py
@@ -29,7 +29,7 @@ except NameError:
 DATETIME_FORMAT_VALIDATION = "%Y-%m-%d %H:%M:%S"
 
 
-class TagValidators(object):
+class TagValidators:
     """ Defines all validator methods.
     """
 
@@ -352,7 +352,7 @@ class TagValidators(object):
         if not field_value:
             raise ValidationError("EOX_TAGGING | The field '{}' is required and must be equal to '{}'."
                                   .format(field, value))
-        elif field_value.lower() != value.lower():
+        if field_value.lower() != value.lower():
             raise ValidationError("EOX_TAGGING | The field '{}' must be equal to '{}'.".format(field, value))
 
     def validate_between(self, field, value):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
 # Main requirements of your plugin application.
 -c constraints.txt
 
+eox-audit-model
 eox-core

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,23 +4,251 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via kombu
-billiard==3.6.3.0         # via celery
-celery==4.4.7             # via eox-core
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
-django==1.11.29           # via edx-opaque-keys, eox-core
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, eox-core
-edx-opaque-keys[django]==0.4.4  # via -c requirements/constraints.txt, eox-core
-eox-core==2.14.0          # via -r requirements/base.in
-importlib-metadata==2.0.0  # via kombu
-kombu==4.6.11             # via celery
-pathlib2==2.3.5           # via importlib-metadata
-pbr==5.5.0                # via stevedore
-pymongo==3.11.0           # via edx-opaque-keys
-pytz==2020.1              # via celery, django
-scandir==1.10.0           # via pathlib2
-six==1.15.0               # via edx-opaque-keys, pathlib2, stevedore
-stevedore==1.32.0         # via edx-opaque-keys
-vine==1.3.0               # via amqp, celery
-zipp==1.2.0               # via importlib-metadata
+amqp==2.6.1
+    # via kombu
+appdirs==1.4.4
+    # via fs
+billiard==3.6.3.0
+    # via celery
+celery==4.4.7
+    # via
+    #   eox-core
+    #   event-tracking
+certifi==2020.12.5
+    # via requests
+cffi==1.14.4
+    # via cryptography
+chardet==4.0.0
+    # via requests
+coreapi==2.3.3
+    # via drf-yasg
+coreschema==0.0.4
+    # via
+    #   coreapi
+    #   drf-yasg
+cryptography==3.2.1
+    # via pyjwt
+django-crum==0.7.9
+    # via
+    #   edx-django-utils
+    #   edx-proctoring
+    #   eox-audit-model
+django-filter==2.4.0
+    # via eox-core
+django-ipware==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-proctoring
+    #   eox-audit-model
+django-model-utils==4.1.1
+    # via
+    #   edx-proctoring
+    #   edx-when
+django-oauth-toolkit==1.3.3
+    # via eox-core
+django-oauth2-provider==0.2.6.1
+    # via eox-core
+django-waffle==2.1.0
+    # via
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   eox-core
+django-webpack-loader==0.7.0
+    # via edx-proctoring
+django==2.2.18
+    # via
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   django-oauth-toolkit
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-opaque-keys
+    #   edx-proctoring
+    #   edx-when
+    #   eox-audit-model
+    #   event-tracking
+    #   jsonfield2
+    #   rest-condition
+djangorestframework==3.9.4
+    # via
+    #   -c requirements/constraints.txt
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   eox-core
+    #   rest-condition
+drf-jwt==1.17.3
+    # via edx-drf-extensions
+drf-yasg==1.17.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via eox-core
+edx-django-utils==3.13.0
+    # via
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   edx-when
+edx-drf-extensions==6.4.0
+    # via
+    #   edx-proctoring
+    #   edx-when
+edx-opaque-keys[django]==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   edx-when
+    #   eox-core
+edx-proctoring==2.6.7
+    # via eox-core
+edx-rest-api-client==5.3.0
+    # via edx-proctoring
+edx-when==2.0.0
+    # via edx-proctoring
+eox-audit-model==0.2.1
+    # via -r requirements/base.in
+eox-core==4.4.0
+    # via -r requirements/base.in
+event-tracking==1.0.4
+    # via edx-proctoring
+fs==2.4.12
+    # via xblock
+future==0.18.2
+    # via pyjwkest
+idna==2.10
+    # via requests
+importlib-metadata==2.1.1
+    # via kombu
+inflection==0.5.1
+    # via drf-yasg
+itypes==1.2.0
+    # via coreapi
+jinja2==2.11.3
+    # via coreschema
+jsonfield2==4.0.0.post0
+    # via edx-proctoring
+kombu==4.6.11
+    # via celery
+lxml==4.6.2
+    # via xblock
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   xblock
+newrelic==5.24.0.153
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via django-oauth-toolkit
+packaging==20.9
+    # via drf-yasg
+pbr==5.5.1
+    # via stevedore
+psutil==5.8.0
+    # via edx-django-utils
+pycparser==2.20
+    # via cffi
+pycryptodomex==3.9.9
+    # via
+    #   edx-proctoring
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   drf-jwt
+    #   edx-rest-api-client
+pymongo==3.11.3
+    # via
+    #   edx-opaque-keys
+    #   event-tracking
+pyparsing==2.4.7
+    # via packaging
+python-dateutil==2.8.1
+    # via
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   xblock
+pytz==2021.1
+    # via
+    #   celery
+    #   django
+    #   edx-proctoring
+    #   event-tracking
+    #   fs
+    #   xblock
+pyyaml==5.3.1
+    # via xblock
+requests==2.25.1
+    # via
+    #   coreapi
+    #   django-oauth-toolkit
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   slumber
+rest-condition==1.0.3
+    # via edx-drf-extensions
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via drf-yasg
+rules==2.2
+    # via edx-proctoring
+semantic-version==2.8.5
+    # via edx-drf-extensions
+shortuuid==1.0.1
+    # via django-oauth2-provider
+six==1.15.0
+    # via
+    #   cryptography
+    #   drf-yasg
+    #   edx-drf-extensions
+    #   edx-opaque-keys
+    #   event-tracking
+    #   fs
+    #   pyjwkest
+    #   python-dateutil
+    #   stevedore
+    #   xblock
+slumber==0.7.1
+    # via edx-rest-api-client
+sqlparse==0.4.1
+    # via django
+stevedore==1.32.0
+    # via
+    #   edx-django-utils
+    #   edx-opaque-keys
+typing==3.7.4.3
+    # via fs
+uritemplate==3.0.1
+    # via
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.3
+    # via requests
+vine==1.3.0
+    # via
+    #   amqp
+    #   celery
+web-fragments==1.0.0
+    # via xblock
+webob==1.8.6
+    # via xblock
+xblock==1.4.0
+    # via edx-when
+zipp==1.2.0
+    # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,21 +8,12 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Version used in Ironwood version of edx-platform
-edx-opaque-keys<1.0.0
+# Pinned to the same version as eox-core to keep consistency
+pylint==2.5.0
 
-# Already in python3 standard library
-futures; python_version == "2.7"
-
-# pylint version 2.0.0 dropped support for python 2.7
-# See: https://github.com/PyCQA/pylint/blob/master/doc/whatsnew/2.0.rst
-pylint<2.0
-
-# django-filter 2.0 release isn't compatible with python 2
-django-filter<2.0
-
-# mock 4.0.0 release isn't compatible with python 2
-mock<4.0.0
-
-# Version used in Ironwood version of edx-platform
-djangorestframework==3.6.3
+# Version used in Juniper version of edx-platform
+django-ipware==2.1.0
+djangorestframework==3.9.4
+drf-yasg==1.17.0
+edx-opaque-keys==2.1.0
+newrelic<=6.0

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,3 +1,2 @@
-django-filter==1.1.0      # via -c requirements/constraints.txt, -r requirements/test.in
-django==1.11.29           # via -r requirements/base.txt, -r requirements/test.in, django-crum, edx-opaque-keys, eox-core
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.txt, eox-core
+django-filter==2.4.0
+django==2.2.18

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,26 +4,52 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
-babel==2.8.0              # via sphinx
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
-docutils==0.16            # via sphinx
-idna==2.10                # via requests
-imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
-markupsafe==1.1.1         # via jinja2
-packaging==20.4           # via sphinx
-pygments==2.5.2           # via sphinx
-pyparsing==2.4.7          # via packaging
-pytz==2020.1              # via babel
-requests==2.24.0          # via sphinx
-six==1.15.0               # via packaging, sphinx
-snowballstemmer==2.0.0    # via sphinx
-sphinx==1.8.5             # via -r requirements/docs.in
-sphinxcontrib-websupport==1.1.2  # via sphinx
-typing==3.7.4.3           # via sphinx
-urllib3==1.25.10          # via requests
+alabaster==0.7.12
+    # via sphinx
+babel==2.9.0
+    # via sphinx
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+docutils==0.16
+    # via sphinx
+idna==2.10
+    # via requests
+imagesize==1.2.0
+    # via sphinx
+jinja2==2.11.3
+    # via sphinx
+markupsafe==1.1.1
+    # via jinja2
+packaging==20.9
+    # via sphinx
+pygments==2.7.4
+    # via sphinx
+pyparsing==2.4.7
+    # via packaging
+pytz==2021.1
+    # via babel
+requests==2.25.1
+    # via sphinx
+snowballstemmer==2.1.0
+    # via sphinx
+sphinx==3.4.3
+    # via -r requirements/docs.in
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+urllib3==1.26.3
+    # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,9 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,40 +4,408 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via -r requirements/base.txt, kombu
-astroid==1.6.6            # via pylint
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -r requirements/base.txt, eox-core
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
-coverage==5.3             # via -r requirements/test.in
-django-crum==0.7.7        # via -r requirements/test.in
-django-fake-model==0.1.4  # via -r requirements/test.in
-django-oauth2-provider==0.2.6.1  # via -r requirements/test.in
-djangorestframework-oauth==1.1.0  # via -r requirements/test.in
-edx-opaque-keys[django]==0.4.4  # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/test.in, eox-core
-enum34==1.1.10            # via astroid
-eox-core==2.14.0          # via -r requirements/base.txt
-funcsigs==1.0.2           # via mock
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
-importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu
-isort==4.3.21             # via pylint
-kombu==4.6.11             # via -r requirements/base.txt, celery
-lazy-object-proxy==1.5.1  # via astroid
-mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-pycodestyle==2.6.0        # via -r requirements/test.in
-pylint==1.9.5             # via -c requirements/constraints.txt, -r requirements/test.in
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
-pytz==2020.1              # via -r requirements/base.txt, celery, django
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
-shortuuid==0.5.0          # via django-oauth2-provider
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-opaque-keys, mock, pathlib2, pylint, singledispatch, stevedore
-stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-wrapt==1.12.1             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
+amqp==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+appdirs==1.4.4
+    # via
+    #   -r requirements/base.txt
+    #   fs
+astroid==2.4.2
+    # via pylint
+billiard==3.6.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==4.4.7
+    # via
+    #   -r requirements/base.txt
+    #   eox-core
+    #   event-tracking
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.4
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+coreapi==2.3.3
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+coverage==5.4
+    # via -r requirements/test.in
+cryptography==3.2.1
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   edx-django-utils
+    #   edx-proctoring
+    #   eox-audit-model
+django-fake-model==0.1.4
+    # via -r requirements/test.in
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   eox-core
+django-ipware==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-proctoring
+    #   eox-audit-model
+django-model-utils==4.1.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+    #   edx-when
+django-oauth-toolkit==1.3.3
+    # via
+    #   -r requirements/base.txt
+    #   eox-core
+django-oauth2-provider==0.2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   eox-core
+django-waffle==2.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   eox-core
+django-webpack-loader==0.7.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   django-oauth-toolkit
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-opaque-keys
+    #   edx-proctoring
+    #   edx-when
+    #   eox-audit-model
+    #   event-tracking
+    #   jsonfield2
+    #   rest-condition
+djangorestframework-oauth==1.1.0
+    # via -r requirements/test.in
+djangorestframework==3.9.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   eox-core
+    #   rest-condition
+drf-jwt==1.17.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+drf-yasg==1.17.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   eox-core
+edx-django-utils==3.13.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   edx-when
+edx-drf-extensions==6.4.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+    #   edx-when
+edx-opaque-keys[django]==2.1.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   edx-when
+    #   eox-core
+edx-proctoring==2.6.7
+    # via
+    #   -r requirements/base.txt
+    #   eox-core
+edx-rest-api-client==5.3.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+edx-when==2.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+eox-audit-model==0.2.1
+    # via -r requirements/base.txt
+eox-core==4.4.0
+    # via -r requirements/base.txt
+event-tracking==1.0.4
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+fs==2.4.12
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+future==0.18.2
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+importlib-metadata==2.1.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+isort==4.3.21
+    # via pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+jinja2==2.11.3
+    # via
+    #   -r requirements/base.txt
+    #   coreschema
+jsonfield2==4.0.0.post0
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+kombu==4.6.11
+    # via
+    #   -r requirements/base.txt
+    #   celery
+lazy-object-proxy==1.4.3
+    # via astroid
+lxml==4.6.2
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+markupsafe==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+    #   xblock
+mccabe==0.6.1
+    # via pylint
+mock==3.0.5
+    # via -r requirements/test.in
+newrelic==5.24.0.153
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+oauthlib==3.1.0
+    # via
+    #   -r requirements/base.txt
+    #   django-oauth-toolkit
+packaging==20.9
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+pbr==5.5.1
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+psutil==5.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pycodestyle==2.6.0
+    # via -r requirements/test.in
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pycryptodomex==3.9.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-rest-api-client
+pylint==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pymongo==3.11.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+    #   event-tracking
+pyparsing==2.4.7
+    # via
+    #   -r requirements/base.txt
+    #   packaging
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   edx-proctoring
+    #   xblock
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   django
+    #   edx-proctoring
+    #   event-tracking
+    #   fs
+    #   xblock
+pyyaml==5.3.1
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   django-oauth-toolkit
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   pyjwkest
+    #   slumber
+rest-condition==1.0.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+ruamel.yaml.clib==0.2.2
+    # via
+    #   -r requirements/base.txt
+    #   ruamel.yaml
+ruamel.yaml==0.16.12
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+rules==2.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-proctoring
+semantic-version==2.8.5
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+shortuuid==1.0.1
+    # via
+    #   -r requirements/base.txt
+    #   django-oauth2-provider
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   cryptography
+    #   drf-yasg
+    #   edx-drf-extensions
+    #   edx-opaque-keys
+    #   event-tracking
+    #   fs
+    #   mock
+    #   pyjwkest
+    #   python-dateutil
+    #   stevedore
+    #   xblock
+slumber==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-rest-api-client
+sqlparse==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==1.32.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+toml==0.10.2
+    # via pylint
+typed-ast==1.4.2
+    # via astroid
+typing==3.7.4.3
+    # via
+    #   -r requirements/base.txt
+    #   fs
+uritemplate==3.0.1
+    # via
+    #   -r requirements/base.txt
+    #   coreapi
+    #   drf-yasg
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+vine==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   amqp
+    #   celery
+web-fragments==1.0.0
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+webob==1.8.6
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+wrapt==1.12.1
+    # via astroid
+xblock==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-when
+zipp==1.2.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,23 +4,40 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
-packaging==20.4           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
-pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
-pyparsing==2.4.7          # via packaging
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via packaging, pathlib2, tox, virtualenv
-toml==0.10.1              # via tox
-tox==3.20.0               # via -r requirements/tox.in
-typing==3.7.4.3           # via importlib-resources
-virtualenv==20.0.31       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+appdirs==1.4.4
+    # via virtualenv
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+importlib-metadata==2.1.1
+    # via
+    #   pluggy
+    #   tox
+    #   virtualenv
+importlib-resources==3.2.1
+    # via virtualenv
+packaging==20.9
+    # via tox
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.15.0
+    # via
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox==3.21.4
+    # via -r requirements/tox.in
+virtualenv==20.4.2
+    # via tox
+zipp==1.2.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
     ],


### PR DESCRIPTION
This PR adds eox-audit-model as a logging mechanism. In preparation for a future PR that will include swagger documentation using [api-doc-tools](https://github.com/edx/api-doc-tools), the requirements were updated and Ironwood support was dropped.

**Changes**

- Drop python2.7 and django 1.11
- Fix/Disable new linting errors due to pylint upgrade
- Updated requirements
- Add eox-audit-model

This [ eox-core PR ](https://github.com/eduNEXT/eox-core/pull/126)offers more context.