### PR TITLE
ci: add py3.8 test support in circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,13 @@ workflows:
               only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
-              python_version: ["3.5"]
-              django_version: ["django22"]
+              python_version: ["3.5", "3.8"]
+              debian_version: ["stretch", "buster"]
+            exclude:
+              - python_version: "3.5"
+                debian_version: "buster"
+              - python_version: "3.8"
+                debian_version: "stretch"
       - pypi:
           requires:
             - test
@@ -23,17 +28,18 @@ workflows:
             tags:
               only: /v?[0-9]+(\.[0-9]+)*/
             branches:
-              ignore: /.*/ 
+              ignore: /.*/
+
 jobs:
   test:
     parameters:
       django_version:
         type: string
+        default: django22
       python_version:
         type: string
       debian_version:
         type: string
-        default: stretch
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/tox.txt requirements/tox.in
 	$(PIP_COMPILE) -o requirements/docs.txt requirements/docs.in
-	# Let tox control the Django, and django-filter version for tests
-	grep -e "^django==" -e "^django-filter==" requirements/test.txt > requirements/django.txt
-	sed '/^[dD]jango==/d;/^django-filter==/d' requirements/test.txt > requirements/test.tmp
-	mv requirements/test.tmp requirements/test.txt
 
 test-python: clean ## Run test suite.
 	$(TOX) pip install -r requirements/test.txt --exists-action w

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,2 +1,0 @@
-django-filter==2.4.0
-django==2.2.18

--- a/requirements/django22.txt
+++ b/requirements/django22.txt
@@ -1,3 +1,0 @@
-Django>=2.2.16
-djangorestframework==3.9.4
-django-filter==2.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -63,6 +63,11 @@ django-fake-model==0.1.4
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   eox-core
+django-filter==2.4.0
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   eox-core
 django-ipware==2.1.0
     # via
     #   -c requirements/constraints.txt
@@ -94,6 +99,26 @@ django-webpack-loader==0.7.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   django-oauth-toolkit
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   edx-opaque-keys
+    #   edx-proctoring
+    #   edx-when
+    #   eox-audit-model
+    #   event-tracking
+    #   jsonfield2
+    #   rest-condition
+django==2.2.21
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in

--- a/setup.py
+++ b/setup.py
@@ -73,12 +73,13 @@ setup(
     author_email='contact@edunext.co',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=[
         'eox_tagging',

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
-envlist = py27-django111,py35-django{111,22}
+envlist = py{35,38}-django22
 
 [testenv]
 envdir=
     # Use the same environment for all commands running under a specific python version
-    py27: {toxworkdir}/py27
     py35: {toxworkdir}/py35
+    py38: {toxworkdir}/py38
 
 passenv =
     TEST_INTEGRATION
     TEST_DATA
 deps =
-    django111: -r requirements/django.txt
-    django22: -r requirements/django22.txt
     -rrequirements/test.txt
 commands =
     {posargs}


### PR DESCRIPTION
This PR adds python 3.8 support to the circleci configuration

Jira issue: https://edunext.atlassian.net/browse/PS2021-428?atlOrigin=eyJpIjoiNTFlYWEyM2MyOGNlNDQyN2FkZjljNzE1MzhjMDRjZjYiLCJwIjoiaiJ9