### PR TITLE
refactor: make py3.8 compatible

### DIFF
--- a/eox_tagging/api/v1/routers.py
+++ b/eox_tagging/api/v1/routers.py
@@ -6,4 +6,4 @@ from rest_framework.routers import DefaultRouter
 from eox_tagging.api.v1.viewset import TagViewSet
 
 router = DefaultRouter()
-router.register(r'tags', TagViewSet, base_name='tag')
+router.register(r'tags', TagViewSet, basename='tag')

--- a/eox_tagging/edxapp_wrappers/backends/enrollment_l_v1.py
+++ b/eox_tagging/edxapp_wrappers/backends/enrollment_l_v1.py
@@ -1,0 +1,13 @@
+"""
+Backend CourseOverview file, here are all the methods from
+openedx.core.djangoapps.content.course_overviews.
+"""
+
+
+def get_enrollment_object():
+    """Backend to get course overview."""
+    try:
+        from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        CourseOverview = object
+    return CourseOverview

--- a/eox_tagging/validators.py
+++ b/eox_tagging/validators.py
@@ -14,24 +14,15 @@ from eox_core.edxapp_wrapper.enrollments import get_enrollment
 from eox_core.edxapp_wrapper.users import get_edxapp_user
 from opaque_keys import InvalidKeyError  # pylint: disable=ungrouped-imports, useless-suppression
 
-log = logging.getLogger(__name__)
+from eox_tagging.edxapp_wrappers.course_overview import CourseOverview
 
-try:
-    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-except ImportError:
-    CourseOverview = object  # pylint: disable=ungrouped-imports, useless-suppression
-try:
-    # Python 2: "unicode" is built-in
-    unicode  # pylint: disable=undefined-variable, useless-suppression
-except NameError:
-    unicode = str  # pylint: disable=redefined-builtin, useless-suppression
+log = logging.getLogger(__name__)
 
 DATETIME_FORMAT_VALIDATION = "%Y-%m-%d %H:%M:%S"
 
 
 class TagValidators:
-    """ Defines all validator methods.
-    """
+    """ Defines all validator methods."""
 
     def __init__(self, instance):
         """
@@ -235,7 +226,7 @@ class TagValidators:
         object_ = self.instance.get_attribute(object_name)
         data = {
             "username": object_.username,
-            "course_id": unicode(object_.course_id),
+            "course_id": str(object_.course_id),
         }
         try:
             enrollment, _ = get_enrollment(**data)


### PR DESCRIPTION
Make eox-tagging python 3.8 compatible (and lilac) this includes:
1. Add compatible backend
2. Remove encode imports and encode string calls
3. DRF version used in lilac changes base_name to basename (basename in DRF 3.12 is completely deprecated)