### PR TITLE
docs: add owner_type queryparam to swagger docs

### DIFF
--- a/eox_tagging/api/v1/viewset.py
+++ b/eox_tagging/api/v1/viewset.py
@@ -124,6 +124,11 @@ from eox_tagging.models import Tag
             "Shortcut to filter objects of target_type `user` with id `username`.",
         ),
         query_parameter(
+            "owner_type",
+            str,
+            "Shortcut to filter objects of owner_type `user` or `site`.",
+        ),
+        query_parameter(
             "target_type",
             str,
             "The type of the object that was tagged, one of: `course`, `courseenrollment`, `user`",

--- a/eox_tagging/api/v1/viewset.py
+++ b/eox_tagging/api/v1/viewset.py
@@ -131,8 +131,8 @@ from eox_tagging.models import Tag
         query_parameter(
             "target_type",
             str,
-            "The type of the object that was tagged, one of: `course (opaquekeyproxymodel)`"
-            ", `courseenrollment`, `user`",
+            "The type of the object that was tagged, one of: `course (use opaquekeyproxymodel for`"
+            "course overview types), `courseenrollment`, `user`",
         ),
         query_parameter(
             "enrollment_username",

--- a/eox_tagging/api/v1/viewset.py
+++ b/eox_tagging/api/v1/viewset.py
@@ -131,7 +131,8 @@ from eox_tagging.models import Tag
         query_parameter(
             "target_type",
             str,
-            "The type of the object that was tagged, one of: `course`, `courseenrollment`, `user`",
+            "The type of the object that was tagged, one of: `course (opaquekeyproxymodel)`"
+            ", `courseenrollment`, `user`",
         ),
         query_parameter(
             "enrollment_username",


### PR DESCRIPTION
This PR allows us to filter using owner_type in swagger api-docs