### PR TITLE
feat: add support for certificates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 Unreleased
 ----------
 
+Added
+~~~~~
+* Support for tagging Certificate objects.
+
 [2.2.0] - 2021-05-13
 --------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,11 @@
 #
 import os
 import sys
+
+import eox_tagging
+
 sys.path.insert(0, os.path.abspath('../..'))
 oath = sys.path
-import eox_tagging
 
 # -- Project information -----------------------------------------------------
 

--- a/eox_tagging/api/v1/test/test_filters.py
+++ b/eox_tagging/api/v1/test/test_filters.py
@@ -30,6 +30,20 @@ class FilterTest(TestCase):
         )
 
     @patch.object(Tag, 'objects')
+    def test_filter_target_certificate_by_uuid(self, objects_mock):
+        """Used to test filtering tags by target object."""
+        objects_mock.find_all_tags_for = Mock()
+        value = "abdcefg12345"
+        name = "certificate_verify_uuid"
+
+        self.filterset.filter_by_target_object(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type="generatedcertificate",
+            target_id={"verify_uuid": value},
+        )
+
+    @patch.object(Tag, 'objects')
     def test_filter_target_enrollment(self, objects_mock):
         """
         Used to test filtering tags depending on the target type. This also filters courseenrollments
@@ -42,6 +56,28 @@ class FilterTest(TestCase):
         self.filterset.request.query_params = {
             "enrollment_course_id": "course_id",
             "enrollment_username": "username",
+        }
+
+        self.filterset.filter_target_types(objects_mock, name, value)
+
+        objects_mock.find_all_tags_for.assert_called_with(
+            target_type=value,
+            target_id={"username": "username", "course_id": "course_id"},
+        )
+
+    @patch.object(Tag, 'objects')
+    def test_filter_target_certificate(self, objects_mock):
+        """
+        Used to test filtering tags depending on the target type. This also filters generatedcertificate
+        given that we must specify the target type besides the other filter parameters, in this case
+        course_id and username.
+        """
+        objects_mock.find_all_tags_for = Mock()
+        value = "generatedcertificate"
+        name = "target_type"
+        self.filterset.request.query_params = {
+            "certificate_course_id": "course_id",
+            "certificate_username": "username",
         }
 
         self.filterset.filter_target_types(objects_mock, name, value)

--- a/eox_tagging/api/v1/viewset.py
+++ b/eox_tagging/api/v1/viewset.py
@@ -47,12 +47,12 @@ from eox_tagging.models import Tag
     site configuration it can take any string.
 
     - `target_type` (**required**, string, _body_):
-    One of courseoverview, user, courseenrollment
+    One of courseoverview, user, courseenrollment, generatedcertificate
 
     - `target_id` (**required**, string, _body_): Identifier of the target\
       object. For users, username; for courseoverview, course_id and for\
-      courseenrollments a string with the following format: "`username:\
-      course_id`"
+      courseenrollments/generatedcertificates a string with the following format: "`username:\
+      course_id`. For generatedcertificates it can also be its verify_uuid"
 
     - `activation_date` (**optional**, string, _body_):
     DateTime format `YYYY-MM-DD HH:MM:SS`.
@@ -124,6 +124,11 @@ from eox_tagging.models import Tag
             "Shortcut to filter objects of target_type `user` with id `username`.",
         ),
         query_parameter(
+            "certificate_verify_uuid",
+            str,
+            "Shortcut to filter objects of target_type `generatedcertificate` with id `verify_uuid`.",
+        ),
+        query_parameter(
             "owner_type",
             str,
             "Shortcut to filter objects of owner_type `user` or `site`.",
@@ -132,7 +137,7 @@ from eox_tagging.models import Tag
             "target_type",
             str,
             "The type of the object that was tagged, one of: `course (use opaquekeyproxymodel for`"
-            "course overview types), `courseenrollment`, `user`",
+            "course overview types), `courseenrollment`, `user`, `generatedcertificate`",
         ),
         query_parameter(
             "enrollment_username",
@@ -144,6 +149,18 @@ from eox_tagging.models import Tag
             "enrollment_course_id",
             str,
             "Course identifier to be used when target_type=courseenrollment."
+            "Can be omitted and is ignored for a different target_type",
+        ),
+        query_parameter(
+            "certificate_username",
+            str,
+            "User identifier (username) to be used when target_type=generatedcertificate. "
+            "Can be omitted and is ignored for a different target_type",
+        ),
+        query_parameter(
+            "certificate_course_id",
+            str,
+            "Course identifier to be used when target_type=generatedcertificate."
             "Can be omitted and is ignored for a different target_type",
         ),
         query_parameter(

--- a/eox_tagging/models.py
+++ b/eox_tagging/models.py
@@ -28,8 +28,6 @@ OPAQUE_KEY_PROXY_MODEL_TARGETS = [
 
 PROXY_MODEL_NAME = "opaquekeyproxymodel"
 
-COURSE_ENROLLMENT_MODEL_NAME = "courseenrollment"
-
 
 class TagQuerySet(QuerySet):
     """ Tag queryset used as manager."""
@@ -102,10 +100,11 @@ class TagQuerySet(QuerySet):
                 "opaque_key": CourseKey.from_string(object_id),
             }
 
-        if object_type.lower() == COURSE_ENROLLMENT_MODEL_NAME:
+        if object_type.lower() in ["courseenrollment", "generatedcertificate"]:
 
             course_id = object_id.get("course_id")
             username = object_id.get("username")
+            verify_uuid = object_id.get("verify_uuid")
             object_id = {}
 
             if course_id:
@@ -113,6 +112,9 @@ class TagQuerySet(QuerySet):
 
             if username:
                 object_id["user__username"] = username
+
+            if verify_uuid:
+                object_id["verify_uuid"] = verify_uuid
 
         object_instances = ctype.get_all_objects_for_this_type(**object_id)
 

--- a/eox_tagging/settings/test.py
+++ b/eox_tagging/settings/test.py
@@ -54,6 +54,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_TAGGING_BEARER_AUTHENTICATION = 'eox_tagging.edxapp_wrappers.backends.bearer_authentication_i_v1_test'
     settings.DATA_API_DEF_PAGE_SIZE = 1000
     settings.DATA_API_MAX_PAGE_SIZE = 5000
+    settings.EOX_CORE_CERTIFICATES_BACKEND = "eox_core.edxapp_wrapper.backends.certificates_h_v1_test"
     settings.TEST_SITE = 1
 
 

--- a/eox_tagging/test/test_models.py
+++ b/eox_tagging/test/test_models.py
@@ -534,7 +534,6 @@ class TestTagQuerysetManager(TestCase):
 
         self.tagQueryset.create.called_once_with(target_object=opaque_mock)
 
-    # pylint: disable=protected-access
     @patch.object(TagQuerySet, '_get_object_for_this_type')
     def test_find_all_tags_for_course(self, _get_object_for_this_type):
         """Test getting tags with course as target."""


### PR DESCRIPTION
**Description**
This PR allows eox-tagging to tag GeneratedCertificate objects through the eox-tagging API. Using the tag model they can also be tagged passing the object itself.

**How to test**
First, add the following configuration:

```
EOX_TAGGING_DEFINITIONS = [
    {
        "owner_object": "Site",
        "tag_type": "cert_dates",
        "validate_target_object": "GeneratedCertificate"
    }
]
```


**Create a tag using the Tagging API:**

```
{
    "tag_type": "cert_dates",
    "tag_value": "2020-09-09",
    "target_type": "generatedcertificate",
    "target_id": "edx: course-v1:edX+E2E-101+course",
    "owner_type": "site"
}
```
or
```
{
  "tag_value": "2020",
  "tag_type": "cert_dates",
  "target_id": "0441c66eb13d47deb3c79c79027f822b",
  "target_type": "generatedcertificate"
}
```
You can use as `target_id` the format `username: course_id` or the verify_uuid of the certificate

**Get tag for specific course_id and username:**
![image](https://user-images.githubusercontent.com/64440265/136430573-2459023c-2773-4306-b840-f43f3c029b28.png)

![image](https://user-images.githubusercontent.com/64440265/136430512-ad184b75-b261-41ae-b42c-6282fae7e10c.png)

**Ger certificate by verify_uuid**
![image](https://user-images.githubusercontent.com/64440265/136588958-a17872a8-5801-43ac-85b7-d8e1a61f8773.png)
