### PR TITLE
fix: update API url in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ Get list of tags
 
 **Request**
 
-``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" http://BASE_URL_SITE/eox_tagging/api/v1/tags/``
+``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" http://BASE_URL_SITE/eox-tagging/api/v1/tags/``
 
 **Response**
 
@@ -237,7 +237,7 @@ Create tag
 
 **Request**
 
-``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" --data TAG_DATA http://BASE_URL_SITE/eox_tagging/api/v1/tags/``
+``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" --data TAG_DATA http://BASE_URL_SITE/eox-tagging/api/v1/tags/``
 
 Where TAG_DATA:
 
@@ -283,7 +283,7 @@ Delete tag
 
 **Request**
 
-``curl -X DELETE  http://BASE_URL_SITE/eox_tagging/api/v1/tags/EXISTING_KEY_TAG/``
+``curl -X DELETE  http://BASE_URL_SITE/eox-tagging/api/v1/tags/EXISTING_KEY_TAG/``
 
 **Response**
 

--- a/docs/how_to/api.rst
+++ b/docs/how_to/api.rst
@@ -101,7 +101,7 @@ Get list of tags
 
 **Request**
 
-``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" http://BASE_URL_SITE/eox_tagging/api/v1/tags/``
+``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" http://BASE_URL_SITE/eox-tagging/api/v1/tags/``
 
 **Response**
 
@@ -133,7 +133,7 @@ Create tag
 
 **Request**
 
-``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" --data TAG_DATA http://BASE_URL_SITE/eox_tagging/api/v1/tags/``
+``curl -H 'Accept: application/json' -H "Authorization: Bearer AUTHENTICATION_TOKEN" --data TAG_DATA http://BASE_URL_SITE/eox-tagging/api/v1/tags/``
 
 Where TAG_DATA:
 
@@ -174,7 +174,7 @@ Delete tag
 
 **Request**
 
-``curl -X DELETE  http://BASE_URL_SITE/eox_tagging/api/v1/tags/EXISTING_KEY_TAG/``
+``curl -X DELETE  http://BASE_URL_SITE/eox-tagging/api/v1/tags/EXISTING_KEY_TAG/``
 
 **Response**
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR updates the API URL in the current docs. 

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Additional information

The mismatch was reported in [this](https://github.com/eduNEXT/eox-tagging/issues/84) issue.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->