### PR TITLE
fix: get_site arg

### DIFF
--- a/eox_tagging/edxapp_accessors.py
+++ b/eox_tagging/edxapp_accessors.py
@@ -35,7 +35,7 @@ def get_course(**kwargs):
     return course
 
 
-def get_site():
+def get_site(**_kwargs):
     """Function used to get current site."""
     if getattr(settings, "EOX_TAGGING_SKIP_VALIDATIONS", False):  # Use TEST_SITE while testing
         site = Site.objects.get(id=settings.TEST_SITE)


### PR DESCRIPTION
## Description

This PR resolves the tagging issue reported for sites here https://github.com/eduNEXT/eox-tagging/issues/90

I test it and the error displayed in the eox-audit-model is:

`
Traceback (most recent call last):
File "/openedx/venv/lib/python3.8/site-packages/eox_tagging/api/v1/serializers.py", line 63, in create
target_object = get_object_from_edxapp(target_type, **data)
File "/openedx/venv/lib/python3.8/site-packages/eox_tagging/edxapp_accessors.py", line 86, in get_object_from_edxapp
return related_object(**kwargs)
TypeError: get_site() got an unexpected keyword argument 'target_id'
`

## Testing instructions

1. Install the plugin in you instance (you can use [tutor-contrib-edunext-distro](https://github.com/eduNEXT/tutor-contrib-edunext-distro) mango).
2. In the `plugin.py` use ` "version": "dcoa/fix-site-tag"`.
3. Create a tenant configuration of your site and add the `EOX_TAGGING_DEFINITIONS`, example:
```JSON
{
"EOX_TAGGING_DEFINITIONS": [
        {
            "tag_type": "example_tag_4",
            "target_object": "site"
        }
    ]
}

```
4. Now you can use swagger to create the tag `<SITE_DOMAIN>/eox-tagging/api-docs/`
5. Use POST with a body like
 ```JSON
{
"tag_value": "hola_un_valor",
"tag_type": "example_tag_4",
"target_id": "local.overhang.io",
"target_type": "Site"
}

```
Verify the response code 201 and the response body with the tag created. 

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->