### PR TITLE
ci: add dependabot config for enable github action auto update `AP-1514`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1.10.0
+      - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.10.3
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.9.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Description

This PR adds the `dependabot.yml` file to perform automated upgrading to GitHub Actions. The current configuration creates a Weekly PR (on Mondays) with the changes.

Also, the versions of the workflow actions are updated to use the MAJOR version (if possible).

### Jira Issue
[AP-1514](https://edunext.atlassian.net/browse/AP-1514)

[AP-1514]: https://edunext.atlassian.net/browse/AP-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ