### PR TITLE
ci: set fail-fast as False to allow integration tests to continue on nightly Tutor failures

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,6 +6,7 @@ jobs:
     name: Tutor Integration Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         tutor_version: ['<18.0.0', '<19.0.0', 'nightly']
     steps:


### PR DESCRIPTION
## Description

This PR updates the Tutor Integration Tests workflow to ensure that failures in the nightly version of Tutor do not cancel the execution of tests for stable versions (<18.0.0 and <19.0.0).  `fail-fast: false` is added to the strategy, allowing the workflow to proceed even if nightly fails.

This change is important because the nightly version of Tutor is not stable and may occasionally fail due to issues unrelated to our tests. By implementing this update, we ensure that failures in nightly do not block critical tests for stable versions.

**Note:** For more context on why this solution was implemented instead of others, such as continue-on-error, please refer to the conversation in this issue https://github.com/eduNEXT/eox-core/pull/308.