### PR TITLE
chore(integration-tests-workflow): rename 'nightly' to 'main'

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<18.0.0', '<19.0.0', 'nightly']
+        tutor_version: ['<18.0.0', '<19.0.0', 'main']
     steps:
       - name: Run Integration Tests
-        uses: eduNEXT/integration-test-in-tutor@mjh/make-extra-reqs-step-optional
+        uses: eduNEXT/integration-test-in-tutor@main
         with:
           tutor_version: ${{ matrix.tutor_version }}
           app_name: 'eox-tagging'


### PR DESCRIPTION
### Summary  
Renamed the `nightly` version in the Tutor Integration Tests Workflow to `main`. This aligns with the recent Tutor branch renaming discussed [here](https://discuss.openedx.org/t/tutor-branches-rename/14455).

### Details  
- Tutor has officially renamed the `nightly` branch to `main`.  
- Updated the `nightly` tutor_version in the workflow to ensure compatibility with the new branch structure.
