### PR TITLE
feat: add teak and remove redwood tutor versions from integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<19.0.0', '<20.0.0', 'main']
+        tutor_version: ['<20.0.0', '<21.0.0', 'main']
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on ## [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to ## [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v9.2.0](https://github.com/eduNEXT/eox-tagging/compare/v9.1.0...v9.2.0) - (2025-07-01)
+
+### Added
+
+- Integration tests now run against Tutor Teak (`<21.0.0`) instead of Redwood (`<19.0.0`), keeping CI aligned with currently supported Open edX releases.
+
 ## [v9.1.0](https://github.com/eduNEXT/eox-tagging/compare/v9.0.0...v9.1.0) - (2025-06-09)
 
 ### Changed

--- a/eox_tagging/__init__.py
+++ b/eox_tagging/__init__.py
@@ -4,4 +4,4 @@ Init module for eox_tagging.
 
 from __future__ import unicode_literals
 
-__version__ = '9.1.0'
+__version__ = '9.2.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.1.0
+current_version = 9.2.0
 commit = False
 tag = False
 


### PR DESCRIPTION
This PR updates the Tutor versions used in integration tests to include Tutor Teak and remove Redwood support.